### PR TITLE
Fix bold text format typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -589,7 +589,7 @@ Project Name in ViewGit::
 [#git-bindings]
 == Git Bindings
 
-The git plugin provides one binding to support authenticated git opreations over *HTTP* or * HTTPS* protocol, namely `Git Username and Password`.
+The git plugin provides one binding to support authenticated git opreations over *HTTP* or *HTTPS* protocol, namely `Git Username and Password`.
 The git plugin depeneds on the Credential Binding Plugin to support these bindings.
 
 To access the `Git Username and Password` binding in a pipeline job, visit <<credential-binding>>


### PR DESCRIPTION
## Bold text format typo under Git Binding section

A small fix to correct `HTTPS` bold formatting under Git Binding section

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Documentation in README has been updated as necessary

## Types of changes

- [x] Dependency or infrastructure update